### PR TITLE
Further improvements to inclusion of user modules in helpindex

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -35,7 +35,7 @@ if ( NOT CMAKE_CROSSCOMPILING )
   # located in the global installation directory for documentation.
   install( CODE
     "execute_process(
-      COMMAND python -B generate_helpindex.py \"${CMAKE_INSTALL_DOCDIR}\"
+      COMMAND python -B generate_helpindex.py \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}\"
       WORKING_DIRECTORY \"${PROJECT_SOURCE_DIR}/extras/help_generator\"
     )"
     )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,11 +20,13 @@
 if ( NOT CMAKE_CROSSCOMPILING )
   add_custom_target( generate_help ALL )
   # Extract help from all source files in the source code, put them in
-  # doc/help and generate a help index containing links to the help
-  # files.
+  # doc/help and generate a local help index in the build directory containing 
+  # links to the help files.
   add_custom_command( TARGET generate_help POST_BUILD
     COMMAND python -B generate_help.py "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}"
+    COMMAND python -B generate_helpindex.py "${PROJECT_BINARY_DIR}/doc"
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/extras/help_generator"
+    COMMENT "Extracting help information; this may take a litte while."
     )
   # Copy the local doc/help directory to the global installation
   # directory for documentation.

--- a/examples/MyModule/CMakeLists.txt
+++ b/examples/MyModule/CMakeLists.txt
@@ -275,7 +275,9 @@ if ( NOT CMAKE_CROSSCOMPILING )
   # files.
   add_custom_command( TARGET generate_help POST_BUILD
     COMMAND python -B generate_help.py "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}"
+    COMMAND python -B generate_helpindex.py "${PROJECT_BINARY_DIR}/doc"
     WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}/${NEST_DATADIR}/help_generator"
+    COMMENT "Extracting help information; this may take a litte while."
     )
   # Copy the local doc/help directory to the global installation
   # directory for documentation.

--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -23,8 +23,8 @@
 Generate NEST help files
 ========================
 
-Scan all source files for documentation and build the help files and
-the corresponding helpindex.
+Scan all source files for documentation and build the help files.
+The helpindex is built during installation in a separate step.
 """
 
 import os
@@ -32,7 +32,7 @@ import re
 import sys
 import textwrap
 
-from writers import coll_data, write_helpindex
+from writers import coll_data
 from helpers import check_ifdef, create_helpdirs, cut_it
 
 if len(sys.argv) != 3:
@@ -44,15 +44,11 @@ source_dir, build_dir = sys.argv[1:]
 helpdir = os.path.join(build_dir, "doc", "help")
 create_helpdirs(helpdir)
 
-is_MyModule_build = "MyModule" in source_dir
-
 allfiles = []
 for dirpath, dirnames, files in os.walk(source_dir):
-    is_MyModule_dir = "MyModule" in dirpath
-    if not is_MyModule_dir or (is_MyModule_dir and is_MyModule_build):
-        for f in files:
-            if f.endswith((".sli", ".cpp", ".cc", ".h", ".py")):
-                allfiles.append(os.path.join(dirpath, f))
+    for f in files:
+        if f.endswith((".sli", ".cpp", ".cc", ".h", ".py")):
+            allfiles.append(os.path.join(dirpath, f))
 
 num = 0
 full_list = []
@@ -131,5 +127,3 @@ for fname in allfiles:
 
             all_data = coll_data(keywords, documentation, num, helpdir, fname,
                                  sli_command_list)
-
-write_helpindex(helpdir)

--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -46,6 +46,10 @@ create_helpdirs(helpdir)
 
 allfiles = []
 for dirpath, dirnames, files in os.walk(source_dir):
+    if "MyModule" in dirpath and "MyModule" not in source_dir:
+        # Do not generate help from MyModule unless we are building MyModule
+        continue
+
     for f in files:
         if f.endswith((".sli", ".cpp", ".cc", ".h", ".py")):
             allfiles.append(os.path.join(dirpath, f))

--- a/extras/help_generator/generate_helpindex.py
+++ b/extras/help_generator/generate_helpindex.py
@@ -26,6 +26,7 @@ Generate NEST helpindex
 Generate the helpindex containing all help files in the given
 help_dir.
 """
+
 import os
 import sys
 from writers import write_helpindex

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -186,7 +186,7 @@ def write_helpindex(helpdir):
         html_list.append('</tr></table></center>')
         html_list.append('<center><table class="commands" id="%s">'
                          % doubles[0])
-        for item in sorted(filelist, 
+        for item in sorted(filelist,
                            key=lambda name: name.lower().rsplit('/', 1)[1]):
             fitem = open(item, 'r')
             itemtext = fitem.read()

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -146,24 +146,26 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
 
 def write_helpindex(helpdir):
     """
-    Returns index.html and index.hlp
-    --------------------------------
+    Writes helpindex.html and helpindex.hlp
+    ---------------------------------------
 
     """
-    filelist = glob.glob(helpdir + "/*/*.hlp")
+    print(helpdir)
+    filelist = glob.glob(os.path.join(helpdir, '*', '*.hlp'))
     html_list = []
     hlp_list = []
+    print(filelist[:10])
 
     # Loading Template for helpindex.html
-    ftemplate = open('templates/helpindex.tpl.html', 'r')
+    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open('templates/nest.tpl.css', 'r')
+    cssf = open(os.path.join('templates', 'nest.tpl.css'), 'r')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open('templates/footer.tpl.html', 'r')
+    footerf = open(os.path.join('templates', 'footer.tpl.html'), 'r')
     footertempl = footerf.read()
     footerf.close()
 
@@ -176,9 +178,6 @@ def write_helpindex(helpdir):
              ('U', 'u'), ('V', 'v'), ('W', 'w'), ('X', 'x'), ('Z', 'z'), '-',
              ':', '<', '=']
 
-    def key_func(key):
-        return key.lower().rsplit('/', 1)[1]
-
     for doubles in alpha:
         html_list.append('<center><table class="alpha">')
         html_list.append('<table class="letteridx"><tr>')
@@ -187,7 +186,8 @@ def write_helpindex(helpdir):
         html_list.append('</tr></table></center>')
         html_list.append('<center><table class="commands" id="%s">'
                          % doubles[0])
-        for item in sorted(filelist, key=key_func):
+        for item in sorted(filelist, 
+                           key=lambda name: name.lower().rsplit('/', 1)[1]):
             fitem = open(item, 'r')
             itemtext = fitem.read()
             fitem.close()
@@ -225,12 +225,13 @@ def write_helpindex(helpdir):
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
-    f_helpindex = open(helpdir + '/helpindex.html', 'w')
+    print(helpdir)
+    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w')
     f_helpindex.write(indexstring)
     f_helpindex.close()
 
     # Todo: using string template for .hlp
-    f_helphlpindex = open(helpdir + '/helpindex.hlp', 'w')
+    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), 'w')
     f_helphlpindex.write('\n'.join(hlp_list))
     f_helphlpindex.close()
 

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -150,11 +150,9 @@ def write_helpindex(helpdir):
     ---------------------------------------
 
     """
-    print(helpdir)
     filelist = glob.glob(os.path.join(helpdir, '*', '*.hlp'))
     html_list = []
     hlp_list = []
-    print(filelist[:10])
 
     # Loading Template for helpindex.html
     ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r')
@@ -225,7 +223,6 @@ def write_helpindex(helpdir):
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
-    print(helpdir)
     f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w')
     f_helpindex.write(indexstring)
     f_helpindex.close()


### PR DESCRIPTION
@jougs I have re-worked the installation of helpindex some more. Source code and build directory for user modules could be anywhere in the file system and under any name. Per-model help files are created in the user module's build `doc/help` directory during make. Install will then add it to the help directories in the NEST install dir.  We are guaranteed that all help files from all modules will be place here. Therefore, the help index needs to be built based on the files in that directory. This PR makes it happen.