### PR TITLE
- Properly handle exceptions raised in thread-parallel node addition.

### DIFF
--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -53,6 +53,7 @@ NodeManager::NodeManager()
   , wfr_is_used_( false )
   , nodes_vec_network_size_( 0 ) // zero to force update
   , num_active_nodes_( 0 )
+  , exceptions_raised_()  // cannot call kernel(), not complete yet
 {
 }
 
@@ -131,12 +132,9 @@ NodeManager::add_node( index model_id, long n )
   assert( model != 0 );
   model->deprecation_warning( "Create" );
 
-  // TODO480: We should reconsider if it is really smart that max_gid is
-  // the largest new gid PLUS ONE. This leads to -1 in several places below
-  // and is a bit confusing.
   const index min_gid = local_nodes_.at( 0 ).get_max_gid() + 1;
-  const index max_gid = min_gid + n;
-  if ( max_gid > local_nodes_.at( 0 ).max_size() or max_gid < min_gid )
+  const index max_gid = min_gid + n - 1;
+  if ( max_gid >= local_nodes_.at( 0 ).max_size() or max_gid < min_gid )
   {
     LOG( M_ERROR,"NodeManager::add_node",
 	 "Requested number of nodes will overflow the memory. "
@@ -144,152 +142,35 @@ NodeManager::add_node( index model_id, long n )
     throw KernelException( "OutOfMemory" );
   }
 
-  kernel().modelrange_manager.add_range( model_id, min_gid, max_gid - 1 );
+  kernel().modelrange_manager.add_range( model_id, min_gid, max_gid );
 
-  // Nodes are created in parallel by all threads. The algorithm is
-  // the same for all types of nodes:
-  // 1. reserve additional space in the thread-local SparseNodeArray
-  // 2. reserve additional space in the corresponding thread-local
-  //    model pool
-  // 3. create the node and set its properties
-  // 4. register the new node in the thread-local SparseNodeArray
-  //
-  // In order to guarantee a consistent representation, we set the new
-  // maximum gid on all SparseNodeArrays.
-  //
-  // We need to distinguish three cases for the creation:
-  // 1. For nodes having proxies (usually neurons), we only create
-  //    a node on the thread responsible for the node. On all other
-  //    threads, we just do nothing. get_node() will take care of
-  //    returning the corresponding proxy for non-existing nodes.
-  // 2. For nodes without proxies and with replicas on each threads
-  //    (normal devices) we create a node on each thread.
-  // 3. For nodes without proxies and only one instance per process
-  //    (MUSIC proxies) we create a node only on thread 0.
-
-  // TODO: put the code in the blocks below in three functions with the
-  //       following signatures in node_manager.h:
-  // void add_node_neurons_( Model* model, index min_gid, index max_gid );
-  // void add_node_devices_( Model* model, index min_gid, index max_gid );
-  // void add_node_music_( Model* model, index min_gid, index max_gid );
+  // clear any exceptions from previous call
+  std::vector< lockPTR< WrappedThreadException > >(  kernel().vp_manager.get_num_threads() ).swap( exceptions_raised_ );
 
   if ( model->has_proxies() )
   {
-    // add_node_neurons_( model, min_gid, max_gid );
-
-	// upper limit for number of neurons per thread; in practice, either
-	// max_new_per_thread-1 or max_new_per_thread nodes will be created
-    const size_t num_vps = kernel().vp_manager.get_num_virtual_processes();
-    const size_t max_new_per_thread = static_cast< size_t >( std::ceil(
-    		static_cast< double >( max_gid - min_gid ) / num_vps ) );
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-    {
-      const index t = kernel().vp_manager.get_thread_id();
-      // TODO480: We should move more of the reservation logic into the
-      // SparseNodeArray. We should tell SNA only max_gid-1 and whether the model
-      // needs local replicas or not. Then SNA can manage memory. This can reduce
-      // bloat due to round-up when using many Create calls for >1 thread
-      local_nodes_.at( t ).reserve_additional( max_new_per_thread );
-      model->reserve_additional( t, max_new_per_thread );
-
-      // TODO480: temporal manual implementation to sort out logic
-      // Need to find smallest gid with:
-      //   - gid local to this thread
-      //   - gid >= min_gid
-      const size_t vp = kernel().vp_manager.thread_to_vp( t );
-      const size_t min_gid_vp = kernel().vp_manager.suggest_vp( min_gid );
-
-      size_t gid = 0;
-      if ( min_gid_vp == vp )
-      {
-    	gid = min_gid;
-      }
-      else
-      {
-    	gid = ( min_gid / num_vps ) * num_vps + vp;
-    	// bad hack, need to improve ...
-    	if ( gid < min_gid )
-    		gid += num_vps;
-      }
-      // TODO480: Refactor next_vp_local_gid_ so that we can initialize gid as
-      //          index gid = next_vp_local_gid_( min_gid, vp );
-      //if ( vp != vp_of_gid )
-      //{
-      //  gid = next_vp_local_gid_( gid, vp );
-      //}
-
-      while ( gid < max_gid )
-      {
-        Node* node = model->allocate( t );
-        node->set_gid_( gid );
-        node->set_model_id( model->get_model_id() );
-        node->set_thread( t );
-        node->set_vp( vp );
-
-        local_nodes_[ t ].add_local_node( *node );
-        // TODO480: temp fix
-        gid += num_vps;
-	    // gid = next_vp_local_gid_( gid, vp );
-      }
-    }
+    add_neurons_( *model, min_gid, max_gid );
   }
   else if ( not model->one_node_per_process() )
   {
-    // add_node_devices_( model, min_gid, max_gid );
-
-    int n_per_thread = ( max_gid - min_gid ) + 1;
-
-#ifdef _OPENMP
-#pragma omp parallel
-    {
-      index t = kernel().vp_manager.get_thread_id();
-#else // clang-format off
-    for ( index t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
-    {
-#endif // clang-format on
-      local_nodes_[ t ].reserve_additional( n_per_thread );
-      model->reserve_additional( t, n_per_thread );
-
-      for ( index gid = min_gid; gid < max_gid; ++gid )
-      {
-        Node* node = model->allocate( t );
-        node->set_gid_( gid );
-        node->set_model_id( model->get_model_id() );
-        node->set_thread( t );
-        node->set_vp( kernel().vp_manager.thread_to_vp( t ) );
-
-        local_nodes_[ t ].add_local_node( *node );
-      }
-    }
+    add_devices_( *model, min_gid, max_gid );
   }
   else
   {
-    // add_node_music_( model, min_gid, max_gid );
+    add_music_nodes_( *model, min_gid, max_gid );
+  }
 
-    for ( index gid = min_gid; gid < max_gid; ++gid )
+  // check if any exceptions have been raised
+  for ( size_t t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
+  {
+    if ( exceptions_raised_.at( t ).valid() )
     {
-      Node* node = model->allocate( 0 );
-      node->set_gid_( gid );
-      node->set_model_id( model->get_model_id() );
-      node->set_thread( 0 );
-      node->set_vp( kernel().vp_manager.thread_to_vp( 0 ) );
-
-      local_nodes_[ 0 ].add_local_node( *node );
+      throw WrappedThreadException( *( exceptions_raised_.at( t ) ) );
     }
   }
-  
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-  {
-    const size_t t = kernel().vp_manager.get_thread_id();
-    local_nodes_.at( t ).update_max_gid( max_gid-1 );
-  }
 
-  // set off-grid spike communication if necessary
+  // activate off-grid communication only after nodes have been created
+  // successfully
   if ( model->is_off_grid() )
   {
     kernel().event_delivery_manager.set_off_grid_communication( true );
@@ -302,26 +183,145 @@ NodeManager::add_node( index model_id, long n )
   }
 
   return GIDCollectionPTR(
-    new GIDCollectionPrimitive( min_gid, max_gid - 1, model_id ) );
+    new GIDCollectionPrimitive( min_gid, max_gid, model_id ) );
 }
 
-inline index
-NodeManager::next_vp_local_gid_( index gid, thread vp ) const
+
+void
+NodeManager::add_neurons_( Model& model, index min_gid, index max_gid )
 {
-  thread vp_of_gid = kernel().vp_manager.suggest_vp( gid );
-  thread num_vp = kernel().vp_manager.get_num_virtual_processes();
+  // upper limit for number of neurons per thread; in practice, either
+  // max_new_per_thread-1 or max_new_per_thread nodes will be created
+  const size_t num_vps = kernel().vp_manager.get_num_virtual_processes();
+  const size_t max_new_per_thread = static_cast< size_t >(
+    std::ceil( static_cast< double >( max_gid - min_gid + 1 ) / num_vps ) );
 
-  if ( vp < vp_of_gid )
+  #pragma omp parallel
   {
-    return gid + num_vp - vp_of_gid;
+    const index t = kernel().vp_manager.get_thread_id();
+
+    try
+    {
+      // TODO480: We should move more of the reservation logic into the
+      // SparseNodeArray. We should tell SNA only max_gid-1 and whether the
+      // model
+      // needs local replicas or not. Then SNA can manage memory. This can
+      // reduce
+      // bloat due to round-up when using many Create calls for >1 thread
+      local_nodes_.at( t ).reserve_additional( max_new_per_thread );
+      model.reserve_additional( t, max_new_per_thread );
+
+      // TODO480: temporal manual implementation to sort out logic
+      // Need to find smallest gid with:
+      //   - gid local to this thread
+      //   - gid >= min_gid
+      const size_t vp = kernel().vp_manager.thread_to_vp( t );
+      const size_t min_gid_vp = kernel().vp_manager.suggest_vp( min_gid );
+
+      size_t gid = 0;
+      if ( min_gid_vp == vp )
+      {
+        gid = min_gid;
+      }
+      else
+      {
+        gid = ( min_gid / num_vps ) * num_vps + vp;
+        // bad hack, need to improve ...
+        if ( gid < min_gid )
+          gid += num_vps;
+      }
+
+      while ( gid <= max_gid )
+      {
+        Node* node = model.allocate( t );
+        node->set_gid_( gid );
+        node->set_model_id( model.get_model_id() );
+        node->set_thread( t );
+        node->set_vp( vp );
+
+        local_nodes_[ t ].add_local_node( *node );
+        gid += num_vps;
+      }
+      local_nodes_[ t ].update_max_gid( max_gid );
+    }
+    catch ( std::exception& err )
+    {
+      // We must create a new exception here, err's lifetime ends at
+      // the end of the catch block.
+      exceptions_raised_.at( t ) =
+        lockPTR< WrappedThreadException >( new WrappedThreadException( err ) );
+    }
   }
-  if ( vp > vp_of_gid )
+}
+
+void
+NodeManager::add_devices_( Model& model, index min_gid, index max_gid )
+{
+  const size_t n_per_thread = max_gid - min_gid + 1;
+
+  #pragma omp parallel
   {
-    return gid + vp - vp_of_gid;
+    const index t = kernel().vp_manager.get_thread_id();
+    try
+    {
+      local_nodes_[ t ].reserve_additional( n_per_thread );
+      model.reserve_additional( t, n_per_thread );
+
+      for ( index gid = min_gid; gid <= max_gid; ++gid )
+      {
+        Node* node = model.allocate( t );
+        node->set_gid_( gid );
+        node->set_model_id( model.get_model_id() );
+        node->set_thread( t );
+        node->set_vp( kernel().vp_manager.thread_to_vp( t ) );
+
+        local_nodes_[ t ].add_local_node( *node );
+      }
+      local_nodes_[ t ].update_max_gid( max_gid );
+    }
+    catch ( std::exception& err )
+    {
+      // We must create a new exception here, err's lifetime ends at
+      // the end of the catch block.
+      exceptions_raised_.at( t ) =
+        lockPTR< WrappedThreadException >( new WrappedThreadException( err ) );
+    }
   }
 
-  return gid + num_vp;
- }
+}
+
+void
+NodeManager::add_music_nodes_( Model& model, index min_gid, index max_gid )
+{
+  #pragma omp parallel
+  {
+	const size_t t = kernel().vp_manager.get_thread_id();
+
+	try
+	{
+	  if ( t == 0 )
+	  {
+		for ( index gid = min_gid; gid <= max_gid; ++gid )
+	    {
+		  Node* node = model.allocate( 0 );
+		  node->set_gid_( gid );
+		  node->set_model_id( model.get_model_id() );
+		  node->set_thread( 0 );
+		  node->set_vp( kernel().vp_manager.thread_to_vp( 0 ) );
+  		  local_nodes_[ 0 ].add_local_node( *node );
+	    }
+	  }
+	  local_nodes_.at( t ).update_max_gid( max_gid );
+	}
+    catch ( std::exception& err )
+    {
+      // We must create a new exception here, err's lifetime ends at
+      // the end of the catch block.
+      exceptions_raised_.at( t ) =
+        lockPTR< WrappedThreadException >( new WrappedThreadException( err ) );
+    }
+  }
+}
 
 void
 NodeManager::restore_nodes( const ArrayDatum& node_list )
@@ -406,6 +406,7 @@ Node* NodeManager::get_node_indp_thread( index gid )
   thread t = kernel().vp_manager.suggest_vp( gid );
 
   Node* node = local_nodes_[ t ].get_node_by_gid( gid );
+  assert( node != 0 );
 
   if ( not node->has_proxies() )
   {

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -240,10 +240,40 @@ private:
   void prepare_node_( Node* );
 
   /**
-   * Returns the next vp-local gid after the given gid. gids are
-   * distributed onto vps in a round-robin fashion.
+   * Add normal neurons.
+   *
+   * Each neuron is added to exactly one virtual process. On all other
+   * VPs, it is represented by a proxy.
+   *
+   * @param model Model of neuron to create.
+   * @param min_gid GID of first neuron to create.
+   * @param max_gid GID of last neuron to create (inclusive).
    */
-  index next_vp_local_gid_( index gid, thread vp ) const;
+  void add_neurons_( Model& model, index min_gid, index max_gid );
+
+  /**
+   * Add device nodes.
+   *
+   * For device nodes, a clone of the node is added to every virtual process.
+   *
+   * @param model Model of neuron to create.
+   * @param min_gid GID of first neuron to create.
+   * @param max_gid GID of last neuron to create (inclusive).
+   */
+  void add_devices_( Model& model, index min_gid, index max_gid );
+
+  /**
+   * Add MUSIC nodes.
+   *
+   * Nodes for MUSIC communication are added once per MPI process and are
+   * always placed on thread 0.
+   *
+   * @param model Model of neuron to create.
+   * @param min_gid GID of first neuron to create.
+   * @param max_gid GID of last neuron to create (inclusive).
+   */
+  void add_music_nodes_( Model& model, index min_gid, index max_gid );
+
 
 private:
   /**
@@ -271,6 +301,9 @@ private:
   //! Network size when nodes_vec_ was last updated
   index nodes_vec_network_size_;
   size_t num_active_nodes_; //!< number of nodes created by prepare_nodes
+
+  //! Store exceptions raised in thread-parallel sections for later handling
+  std::vector< lockPTR< WrappedThreadException > > exceptions_raised_;
 };
 
 inline index

--- a/testsuite/unittests/test_corr_det.sli
+++ b/testsuite/unittests/test_corr_det.sli
@@ -44,6 +44,7 @@ SeeAlso: correlation_detector
 /tau_max 20.0 def
 
 % First test: parameter setting on model and instance
+(Test 1) ==
 {
   ResetKernel
 
@@ -61,6 +62,7 @@ clear
 ResetKernel
 
 % Second test: error if uncommensurable delta_tau
+(Test 2) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -69,6 +71,7 @@ ResetKernel
 
 
 % Third test: error if uncommensurable tau_max
+(Test 3) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -77,6 +80,7 @@ ResetKernel
 
 
 % Fourth test: error if uncommensurable change of resolution
+(Test 4) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -87,6 +91,7 @@ ResetKernel
 
 
 % Fifth test: proper number of histogram bins under resolution changes
+(Test 5) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -151,6 +156,7 @@ def
 } def
 
 % Sixth test: correlation histogram for time differences in bin centers
+(Test 6) ==
 {
   ResetKernel
 
@@ -164,6 +170,7 @@ def
 } assert_or_die
 
 % Seventh test: correlation histogram for time differences at bin edges
+(Test 7) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -176,12 +183,14 @@ def
 } assert_or_die
 
 % Eight test: test to ensure [1 1] not allowed for /n_events
+(Test 8) ==
 {
   /correlation_detector Create
   << /n_events [1 1] >> SetStatus
 } fail_or_die
 
 % Ninth test: test that reset works
+(Test 9) ==
 {
   ResetKernel
 

--- a/testsuite/unittests/test_corr_matrix_det.sli
+++ b/testsuite/unittests/test_corr_matrix_det.sli
@@ -45,6 +45,7 @@ SeeAlso: correlomatrix_detector
 /N_ch       8 def
 
 % First test: parameter setting on model and instance
+(Test 1) ==
 {
   ResetKernel
   /cd1 /correlomatrix_detector Create def
@@ -62,6 +63,7 @@ ResetKernel
 
 
 % Second test: error if trying to set invalid channel number
+(Test 2) ==
 {
   ResetKernel
   /correlomatrix_detector << /N_channels 0 >> SetDefaults
@@ -74,6 +76,7 @@ ResetKernel
 
 
 % Third test: error if uncommensurable delta_tau
+(Test 3) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -82,6 +85,7 @@ ResetKernel
 
 
 % Fourth test: error if delta_tau even multiple of resolution
+(Test 4) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -90,6 +94,7 @@ ResetKernel
 
 
 % Fifth test: error if uncommensurable tau_max
+(Test 5) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -98,6 +103,7 @@ ResetKernel
 
 
 % Sixth test: error if uncommensurable change of resolution
+(Test 6) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -108,6 +114,7 @@ ResetKernel
 
 
 % Seventh test: proper number of histogram bins under resolution changes
+(Test 7) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -173,6 +180,7 @@ def
 
 
 % Eighth test: correlation histogram for time differences in bin centers
+(Test 8) ==
 {
   ResetKernel
   
@@ -187,6 +195,7 @@ def
 
 
 % Ninth test: test that reset works
+(Test 9) ==
 {
   ResetKernel
 

--- a/testsuite/unittests/test_noise_generator.sli
+++ b/testsuite/unittests/test_noise_generator.sli
@@ -38,6 +38,7 @@ SeeAlso: noise_generator
 /unittest using
 
 % First test: parameter setting on model and instance
+(Test 1) ==
 {
     ResetKernel
     /tdict << /mean 10.5 /std 0.23 /dt 0.5 >> def
@@ -56,6 +57,7 @@ clear
 ResetKernel
 
 % Second test: error if uncommensurable delta_tau
+(Test 2) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -63,6 +65,7 @@ ResetKernel
 } fail_or_die  
 
 % Third test: error if uncommensurable change of resolution
+(Test 3) ==
 {
   ResetKernel
   << /resolution 0.1 >> SetKernelStatus
@@ -72,6 +75,7 @@ ResetKernel
 } fail_or_die  
 
 % Fourth test: recording at two different dt
+(Test 4) ==
 /vb verbosity def
 M_ERROR setverbosity  % suppress warning from time reset
 {


### PR DESCRIPTION
- Split add_node() into three submethods.
- In add_node() and submethods, max_gid is now inclusive.

@jougs @stinebuu This fixes the "IllegalTime" errors and provides some code clean-up. Unit- and regression tests pass now except for the "/Prepare" problem, which we already understand, and a subtle problem with a Bernoulli connectivity test on a very large number of threads; I believe, in that case the test is broken rather than the code (same trouble on Master).