### PR TITLE
Some function name change and making sure all examples run

### DIFF
--- a/examples/nest/ArtificialSynchrony.sli
+++ b/examples/nest/ArtificialSynchrony.sli
@@ -160,17 +160,16 @@ modeldict begin
          /overwrite_files true          % overwrite previous output
        >> SetKernelStatus
 
-  sim 1 eq { /iaf_psc_alpha_canon nr Create pop }
-           { /iaf_psc_alpha nr Create pop } ifelse
-  /neurons 0 GetGlobalNodes def
+  sim 1 eq { /neurons /iaf_psc_alpha_canon nr Create def }
+           { /neurons /iaf_psc_alpha nr Create def } ifelse
 
   % connect neurons all to all
-  neurons {
-   /ii Set
+  neurons cva {
+   /ii Set   
    neurons {
-        dup
+        %dup
         /ii2 Set
-        ii
+        %ii
         %   neq {                       % uncomment to  avoid self connections
                     ii ii2 strength delay Connect
         %   } if
@@ -219,8 +218,6 @@ modeldict begin
   %  detec  << /to_file tofile /withgid true /interval 0.1 >> SetStatus
   /voltmeter Create /volt Set
 
-
-
   volt  << /to_file tofile              % write to file
          /to_memory false               % not to memory
          /withgid true                  % important to know which neuron
@@ -235,7 +232,7 @@ modeldict begin
   neurons {
    dup
    %  detec 1.0 h Connect               % connect spike_detector
-   volt exch 1.0 h Connect              % connect voltmeter
+   volt 0 get exch 1.0 h Connect              % connect voltmeter
   } forall
 
   10000 Simulate                        % simulate for 10s

--- a/examples/nest/ArtificialSynchrony.sli
+++ b/examples/nest/ArtificialSynchrony.sli
@@ -164,17 +164,8 @@ modeldict begin
            { /neurons /iaf_psc_alpha nr Create def } ifelse
 
   % connect neurons all to all
-  neurons cva {
-   /ii Set   
-   neurons {
-        %dup
-        /ii2 Set
-        %ii
-        %   neq {                       % uncomment to  avoid self connections
-                    ii ii2 strength delay Connect
-        %   } if
-        } forall
-  } forall
+  /autapses_bool true def         % Change to false to avoid self connections
+  neurons neurons << /rule /all_to_all /autapses autapses_bool >> << /weight strength /delay delay >> Connect
 
   /*                                    % uncomment to verify connections
   %% Readout if everything works

--- a/examples/nest/Potjans_2014/microcircuit.sli
+++ b/examples/nest/Potjans_2014/microcircuit.sli
@@ -209,6 +209,8 @@
 % th_spike_detector_GID
 /CreateNetworkNodes
 {
+    % TODO480. This example still contains subnets, I don't have enough
+    % knowledge of the model to remove.
     % create and configure neurons
     neuron_model model_params SetDefaults
     % arrays of GIDs:

--- a/models/stdp_dopa_connection.cpp
+++ b/models/stdp_dopa_connection.cpp
@@ -83,7 +83,7 @@ STDPDopaCommonProperties::set_status( const DictionaryDatum& d,
   long vtgid;
   if ( updateValue< long >( d, names::vt, vtgid ) )
   {
-    vt_ = dynamic_cast< volume_transmitter* >( kernel().node_manager.get_node(
+    vt_ = dynamic_cast< volume_transmitter* >( kernel().node_manager.get_node_or_proxy(
       vtgid, kernel().vp_manager.get_thread_id() ) );
     if ( vt_ == 0 )
     {

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -287,7 +287,7 @@ nest::ConnBuilder::change_connected_synaptic_elements( index sgid,
   // check whether the source is on this mpi machine
   if ( kernel().node_manager.is_local_gid( sgid ) )
   {
-    Node* const source = kernel().node_manager.get_node( sgid, tid );
+    Node* const source = kernel().node_manager.get_node_or_proxy( sgid, tid );
     const thread source_thread = source->get_thread();
 
     // check whether the source is on our thread
@@ -305,7 +305,7 @@ nest::ConnBuilder::change_connected_synaptic_elements( index sgid,
   }
   else
   {
-    Node* const target = kernel().node_manager.get_node( tgid, tid );
+    Node* const target = kernel().node_manager.get_node_or_proxy( tgid, tid );
     const thread target_thread = target->get_thread();
     // check whether the target is on our thread
     if ( tid != target_thread )
@@ -723,7 +723,7 @@ nest::OneToOneBuilder::disconnect_()
         }
 
         Node* const target =
-          kernel().node_manager.get_node( ( *tgid ).gid, tid );
+          kernel().node_manager.get_node_or_proxy( ( *tgid ).gid, tid );
         const thread target_thread = target->get_thread();
 
         // check whether the target is on our thread
@@ -784,7 +784,7 @@ nest::OneToOneBuilder::sp_connect_()
           continue;
         }
         Node* const target =
-          kernel().node_manager.get_node( ( *tgid ).gid, tid );
+          kernel().node_manager.get_node_or_proxy( ( *tgid ).gid, tid );
         const thread target_thread = target->get_thread();
 
         single_connect_( ( *sgid ).gid, *target, target_thread, rng );
@@ -830,7 +830,7 @@ nest::OneToOneBuilder::sp_disconnect_()
           continue;
         }
         Node* const target =
-          kernel().node_manager.get_node( ( *tgid ).gid, tid );
+          kernel().node_manager.get_node_or_proxy( ( *tgid ).gid, tid );
         const thread target_thread = target->get_thread();
 
         single_disconnect_( ( *sgid ).gid, *target, target_thread );
@@ -981,7 +981,7 @@ nest::AllToAllBuilder::sp_connect_()
             continue;
           }
           Node* const target =
-            kernel().node_manager.get_node( ( *tgid ).gid, tid );
+            kernel().node_manager.get_node_or_proxy( ( *tgid ).gid, tid );
           const thread target_thread = target->get_thread();
           single_connect_( ( *sgid ).gid, *target, target_thread, rng );
         }
@@ -1025,7 +1025,7 @@ nest::AllToAllBuilder::disconnect_()
         }
 
         Node* const target =
-          kernel().node_manager.get_node( ( *tgid ).gid, tid );
+          kernel().node_manager.get_node_or_proxy( ( *tgid ).gid, tid );
         const thread target_thread = target->get_thread();
 
         // check whether the target is on our thread
@@ -1085,7 +1085,7 @@ nest::AllToAllBuilder::sp_disconnect_()
             continue;
           }
           Node* const target =
-            kernel().node_manager.get_node( ( *tgid ).gid, tid );
+            kernel().node_manager.get_node_or_proxy( ( *tgid ).gid, tid );
           const thread target_thread = target->get_thread();
           single_disconnect_( ( *sgid ).gid, *target, target_thread );
         }
@@ -1527,7 +1527,7 @@ nest::FixedTotalNumberBuilder::connect_()
           // targets_on_vp vector
           const long tgid = thread_local_targets[ t_index ];
 
-          Node* const target = kernel().node_manager.get_node( tgid, tid );
+          Node* const target = kernel().node_manager.get_node_or_proxy( tgid, tid );
           const thread target_thread = target->get_thread();
 
           if ( autapses_ or sgid != tgid )
@@ -1772,7 +1772,7 @@ nest::SPBuilder::connect_( const std::vector< index >& sources,
           skip_conn_parameter_( tid );
           continue;
         }
-        Node* const target = kernel().node_manager.get_node( *tgid, tid );
+        Node* const target = kernel().node_manager.get_node_or_proxy( *tgid, tid );
         const thread target_thread = target->get_thread();
 
         single_connect_( *sgid, *target, target_thread, rng );

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -382,7 +382,7 @@ nest::ConnectionManager::connect( index sgid,
   double w )
 {
   const thread tid = kernel().vp_manager.get_thread_id();
-  Node* source = kernel().node_manager.get_node( sgid, target_thread );
+  Node* source = kernel().node_manager.get_node_or_proxy( sgid, target_thread );
 
   // target is a normal node or device with proxies
   if ( target->has_proxies() )
@@ -421,9 +421,9 @@ nest::ConnectionManager::connect( index sgid,
         kernel().vp_manager.suggest_vp( target->get_gid() ) );
       if ( target_thread == tid )
       {
-        source = kernel().node_manager.get_node( sgid, target_thread );
+        source = kernel().node_manager.get_node_or_proxy( sgid, target_thread );
         target =
-          kernel().node_manager.get_node( target->get_gid(), target_thread );
+          kernel().node_manager.get_node_or_proxy( target->get_gid(), target_thread );
         connect_( *source, *target, sgid, target_thread, syn, d, w );
       }
     }
@@ -451,7 +451,7 @@ nest::ConnectionManager::connect( index sgid,
   double w )
 {
   const thread tid = kernel().vp_manager.get_thread_id();
-  Node* source = kernel().node_manager.get_node( sgid, target_thread );
+  Node* source = kernel().node_manager.get_node_or_proxy( sgid, target_thread );
 
   // target is a normal node or device with proxies
   if ( target->has_proxies() )
@@ -490,9 +490,9 @@ nest::ConnectionManager::connect( index sgid,
         kernel().vp_manager.suggest_vp( target->get_gid() ) );
       if ( target_thread == tid )
       {
-        source = kernel().node_manager.get_node( sgid, target_thread );
+        source = kernel().node_manager.get_node_or_proxy( sgid, target_thread );
         target =
-          kernel().node_manager.get_node( target->get_gid(), target_thread );
+          kernel().node_manager.get_node_or_proxy( target->get_gid(), target_thread );
         connect_( *source, *target, sgid, target_thread, syn, params, d, w );
       }
     }
@@ -524,9 +524,9 @@ nest::ConnectionManager::connect( index sgid,
     return false;
   }
 
-  Node* target = kernel().node_manager.get_node( tgid, tid );
+  Node* target = kernel().node_manager.get_node_or_proxy( tgid, tid );
   thread target_thread = target->get_thread();
-  Node* source = kernel().node_manager.get_node( sgid, target_thread );
+  Node* source = kernel().node_manager.get_node_or_proxy( sgid, target_thread );
 
   // target is a normal node or device with proxies
   if ( target->has_proxies() )
@@ -565,9 +565,9 @@ nest::ConnectionManager::connect( index sgid,
         kernel().vp_manager.suggest_vp( target->get_gid() ) );
       if ( target_thread == tid )
       {
-        source = kernel().node_manager.get_node( sgid, target_thread );
+        source = kernel().node_manager.get_node_or_proxy( sgid, target_thread );
         target =
-          kernel().node_manager.get_node( target->get_gid(), target_thread );
+          kernel().node_manager.get_node_or_proxy( target->get_gid(), target_thread );
         connect_( *source, *target, sgid, target_thread, syn, params );
       }
     }
@@ -818,7 +818,7 @@ nest::ConnectionManager::data_connect_single( const index source_id,
       Node* target = 0;
       try
       {
-        target = kernel().node_manager.get_node( target_ids[ i ], tid );
+        target = kernel().node_manager.get_node_or_proxy( target_ids[ i ], tid );
       }
       catch ( UnknownNode& e )
       {
@@ -905,7 +905,7 @@ nest::ConnectionManager::data_connect_connectome( const ArrayDatum& connectome )
   {
     DictionaryDatum cd = getValue< DictionaryDatum >( *ct );
     index target_gid = static_cast< size_t >( ( *cd )[ names::target ] );
-    Node* target_node = kernel().node_manager.get_node( target_gid );
+    Node* target_node = kernel().node_manager.get_node_or_proxy( target_gid );
     size_t thr = target_node->get_thread();
 
     size_t syn_id = 0;
@@ -926,7 +926,7 @@ nest::ConnectionManager::data_connect_connectome( const ArrayDatum& connectome )
         throw UnknownModelName( synmodel_name );
       }
     }
-    Node* source_node = kernel().node_manager.get_node( source_gid );
+    Node* source_node = kernel().node_manager.get_node_or_proxy( source_gid );
     connect_( *source_node, *target_node, source_gid, thr, syn_id, cd );
   }
   return true;

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -225,7 +225,7 @@ ConnectorBase::send_weight_event( const CommonSynapseProperties& cp,
     wr_e.set_delay( e.get_delay() );
     // set weight_recorder as receiver
     index wr_gid = cp.get_weight_recorder();
-    Node* wr_node = kernel().node_manager.get_node( wr_gid, t );
+    Node* wr_node = kernel().node_manager.get_node_or_proxy( wr_gid, t );
     wr_e.set_receiver( *wr_node );
     // but the gid of the postsynaptic node as receiver gid
     wr_e.set_receiver_gid( e.get_receiver().get_gid() );

--- a/nestkernel/gid_collection.cpp
+++ b/nestkernel/gid_collection.cpp
@@ -173,7 +173,7 @@ GIDCollection::create_( const std::vector< index >& gids )
   index current_first = gids[ 0 ];
   index current_last = current_first;
   index current_model =
-    kernel().node_manager.get_node( gids[ 0 ] )->get_model_id();
+    kernel().node_manager.get_node_or_proxy( gids[ 0 ] )->get_model_id();
 
   std::vector< GIDCollectionPrimitive > parts;
 
@@ -181,7 +181,7 @@ GIDCollection::create_( const std::vector< index >& gids )
         gid != gids.end();
         ++gid )
   {
-    index next_model = kernel().node_manager.get_node( *gid )->get_model_id();
+    index next_model = kernel().node_manager.get_node_or_proxy( *gid )->get_model_id();
 
     if ( next_model == current_model and *gid == ( current_last + 1 ) )
     {
@@ -251,10 +251,10 @@ GIDCollectionPrimitive::GIDCollectionPrimitive( index first, index last )
   assert( first_ <= last_ );
 
   // find the model_id
-  const int model_id = kernel().node_manager.get_node( first )->get_model_id();
+  const int model_id = kernel().node_manager.get_node_or_proxy( first )->get_model_id();
   for ( index gid = ++first; gid <= last; ++gid )
   {
-    if ( model_id != kernel().node_manager.get_node( gid )->get_model_id() )
+    if ( model_id != kernel().node_manager.get_node_or_proxy( gid )->get_model_id() )
     {
       throw BadProperty( "model ids does not match" );
     }

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -92,7 +92,7 @@ print_nodes_to_stream( std::ostream& ostr )
 librandom::RngPtr
 get_vp_rng_of_gid( index target )
 {
-  Node* target_node = kernel().node_manager.get_node_indp_thread( target );
+  Node* target_node = kernel().node_manager.get_node_or_proxy( target );
 
   if ( not kernel().node_manager.is_local_node( target_node ) )
   {
@@ -165,7 +165,7 @@ set_connection_status( const ConnectionDatum& conn,
   long port = getValue< long >( conn_dict, nest::names::port );
   long gid = getValue< long >( conn_dict, nest::names::source );
   thread tid = getValue< long >( conn_dict, nest::names::target_thread );
-  kernel().node_manager.get_node( gid ); // Just to check if the node exists
+  kernel().node_manager.get_node_or_proxy( gid, tid ); // Just to check if the node exists
 
   dict->clear_access_flags();
 
@@ -183,7 +183,7 @@ DictionaryDatum
 get_connection_status( const ConnectionDatum& conn )
 {
   long gid = conn.get_source_gid();
-  kernel().node_manager.get_node( gid ); // Just to check if the node exists
+  kernel().node_manager.get_node_or_proxy( gid ); // Just to check if the node exists
 
   return kernel().connection_manager.get_synapse_status( gid,
     conn.get_synapse_model_id(),

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -300,7 +300,7 @@ NestModule::GetStatus_CFunction::execute( SLIInterpreter* i ) const
   ConnectionDatum conn = getValue< ConnectionDatum >( i->OStack.pick( 0 ) );
 
   long gid = conn.get_source_gid();
-  kernel().node_manager.get_node( gid ); // Just to check if the node exists
+  kernel().node_manager.get_node_or_proxy( gid ); // Just to check if the node exists
 
   DictionaryDatum result_dict =
     kernel().connection_manager.get_synapse_status( gid,
@@ -675,7 +675,7 @@ NestModule::Disconnect_i_i_lFunction::execute( SLIInterpreter* i ) const
   // check whether the target is on this process
   if ( kernel().node_manager.is_local_gid( target ) )
   {
-    Node* const target_node = kernel().node_manager.get_node_indp_thread( target );
+    Node* const target_node = kernel().node_manager.get_node_or_proxy( target );
 
     const thread target_thread = target_node->get_thread();
 

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -335,7 +335,7 @@ NodeManager::restore_nodes( const ArrayDatum& node_list )
     std::string model_name = ( *node_props )[ names::model ];
     index model_id = kernel().model_manager.get_model_id( model_name.c_str() );
     GIDCollectionPTR node = add_node( model_id );
-    Node* node_ptr = get_node_or_proxy( ( *node->begin() ).gid, kernel().vp_manager.get_thread_id() );
+    Node* node_ptr = get_node_or_proxy( ( *node->begin() ).gid );
     // we call directly set_status on the node
     // to bypass checking of unused dictionary items.
     node_ptr->set_status_base( node_props );
@@ -345,7 +345,7 @@ NodeManager::restore_nodes( const ArrayDatum& node_list )
 void
 NodeManager::init_state( index GID )
 {
-  Node* n = get_node_or_proxy( GID, kernel().vp_manager.get_thread_id() );
+  Node* n = get_node_or_proxy( GID );
   if ( n == 0 )
   {
     throw UnknownNode( GID );

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -135,20 +135,29 @@ public:
    *
    * @ingroup net_access
    */
-  Node* get_node( index, thread thr = 0 );
+  Node* get_node_or_proxy( index, thread );
+
+  /**
+   * Return pointer of the specified Node.
+   * @param i Index of the specified Node.
+   */
+  Node* get_node_or_proxy( index );
 
   /*
-   * Return Node on the thread we are on.
+   * Return pointer of Node on the thread we are on.
    *
    * If the node has proxies, it returns the node on the first thread (used by
    * recorders).
    *
    * @params gid Index of the Node.
    */
-  Node* get_node_indp_thread( index );
+  Node* get_mpi_local_node_or_device_head( index );
 
   /*
-   * Return local Node on thread given by specified gid.
+   * Return pointer of Node.
+   *
+   * If the Node is not on the given thread, the function returns 0.
+   *
    * @param gid Index of the Node.
    * @param t Thread index of the Node.
    */

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -256,7 +256,7 @@ SPManager::disconnect( index sgid,
   thread target_thread,
   index syn )
 {
-  Node* const source = kernel().node_manager.get_node( sgid );
+  Node* const source = kernel().node_manager.get_node_or_proxy( sgid );
   // normal nodes and devices with proxies
   if ( target->has_proxies() )
   {
@@ -272,7 +272,7 @@ SPManager::disconnect( index sgid,
       && ( source->has_proxies() ) )
     {
       target_thread = source->get_thread();
-      target = kernel().node_manager.get_node( target->get_gid(), sgid );
+      target = kernel().node_manager.get_node_or_proxy( target->get_gid(), target_thread );
     }
     // thread target_thread = target->get_thread();
 
@@ -288,7 +288,7 @@ SPManager::disconnect( index sgid,
     const thread n_threads = kernel().vp_manager.get_num_threads();
     for ( thread t = 0; t < n_threads; t++ )
     {
-      target = kernel().node_manager.get_node( target->get_gid(), t );
+      target = kernel().node_manager.get_node_or_proxy( target->get_gid(), t );
       target_thread = target->get_thread();
       kernel().connection_manager.disconnect(
         *target, sgid, target_thread, syn ); // tgid
@@ -606,7 +606,7 @@ SPManager::delete_synapse( index sgid,
   const int tid = kernel().vp_manager.get_thread_id();
   if ( kernel().node_manager.is_local_gid( sgid ) )
   {
-    Node* const source = kernel().node_manager.get_node( sgid );
+    Node* const source = kernel().node_manager.get_node_or_proxy( sgid );
     const thread source_thread = source->get_thread();
     if ( tid == source_thread )
     {
@@ -616,7 +616,7 @@ SPManager::delete_synapse( index sgid,
 
   if ( kernel().node_manager.is_local_gid( tgid ) )
   {
-    Node* const target = kernel().node_manager.get_node( tgid );
+    Node* const target = kernel().node_manager.get_node_or_proxy( tgid );
     thread target_thread = target->get_thread();
     if ( tid == target_thread )
     {

--- a/pynest/examples/gap_junctions_inhibitory_network.py
+++ b/pynest/examples/gap_junctions_inhibitory_network.py
@@ -127,12 +127,15 @@ and connecting the neurons using the `make_symmetric` flag for
 `one_to_one` connections.
 """
 n_connection = int(n_neuron * gap_per_neuron / 2)
+neuron_list = [ n for n in neurons]
 connections = numpy.transpose(
-    [random.sample(neurons, 2) for _ in range(n_connection)])
+    [random.sample(neuron_list, 2) for _ in range(n_connection)])
 
-nest.Connect(connections[0], connections[1],
-             {'rule': 'one_to_one', 'make_symmetric': True},
-             {'model': 'gap_junction', 'weight': gap_weight})
+for indx in range(n_connection):
+    nest.Connect(nest.GIDCollection([connections[0][indx]]),
+                 nest.GIDCollection([connections[1][indx]]),
+                 {'rule': 'one_to_one', 'make_symmetric': True},
+                 {'model': 'gap_junction', 'weight': gap_weight})
 
 """
 In the end we start the simulation and plot the spike pattern.

--- a/pynest/examples/sinusoidal_gamma_generator.py
+++ b/pynest/examples/sinusoidal_gamma_generator.py
@@ -225,7 +225,7 @@ spikes = step(t, n,
               {'rate': 50.0, },
               seed=123, dt=dt)
 plot_hist(spikes)
-exp = np.ones(steps)
+exp = np.ones(int(steps))
 exp[:int(steps / 2)] *= 20
 exp[int(steps / 2):] *= 50
 plt.plot(exp, 'r')
@@ -246,7 +246,7 @@ spikes = step(t, n,
                'frequency': 0., 'phase': 0.},
               seed=123, dt=dt)
 plot_hist(spikes)
-exp = np.ones(steps)
+exp = np.ones(int(steps))
 exp[:int(steps / 2)] *= 80
 exp[int(steps / 2):] *= 40
 plt.plot(exp, 'r')
@@ -316,7 +316,7 @@ spikes = step(t, n,
               seed=123, dt=1.)
 plot_hist(spikes)
 exp = np.zeros(int(steps))
-exp[:int(steps / 2)] = 40. * np.ones(steps / 2)
+exp[:int(steps / 2)] = 40. * np.ones(int(steps / 2))
 exp[int(steps / 2):] = (40. + 40. * np.sin(np.arange(0, t / 1000. * np.pi * 20,
                                                      t / 1000. * np.pi * 20. /
                                                      (steps / 2))))


### PR DESCRIPTION
Updated a few examples so they run, and changed the names of the different get_nodes functions so it is easier to separate them from one another, and understand what they do.

All examples now run (both sli and python) except the Potjans sli example.