### PR TITLE
made python_object_to_datum() available to ` via Cython

### DIFF
--- a/pynest/nest/lib/hl_api_models.py
+++ b/pynest/nest/lib/hl_api_models.py
@@ -22,9 +22,10 @@
 """
 Functions for model handling
 """
+import pyximport
+pyximport.install()
 
 from .hl_api_helper import *
-
 
 @check_stack
 def Models(mtype="all", sel=None):
@@ -77,7 +78,7 @@ def Models(mtype="all", sel=None):
         models = [x for x in models if x.find(sel) >= 0]
 
     models.sort()
-
+    print("XXXXXXXXXXXXXXXXX: MODELS = " + str(models))
     return tuple(models)
 
 
@@ -115,6 +116,7 @@ def SetDefaults(model, params, val=None):
         If given, params has to be the name of a model property.
     """
 
+    print("XXXXXXXXXXXXXXXXX: setdefaults")
     if val is not None:
         if is_literal(params):
             params = {params: val}
@@ -186,11 +188,21 @@ def CopyModel(existing, new, params=None):
         Default parameters assigned to the copy. Not provided parameters are
         taken from the existing model.
     """
+    from nest.pynestkernel import _python_object_to_datum
 
     model_deprecation_warning(existing)
+    params_datum_ptr = kernel._python_object_to_datum(params)
+    copy_model( existing, new, params_datum_ptr )
 
-    if params is not None:
-        sps(params)
-        sr("/%s /%s 3 2 roll CopyModel" % (existing, new))
-    else:
-        sr("/%s /%s CopyModel" % (existing, new))
+    
+
+
+
+    # model_deprecation_warning(existing)
+
+    # if params is not None:
+    #     sps(params)
+    #     sr("/%s /%s 3 2 roll CopyModel" % (existing, new))
+    # else:
+    #     sr("/%s /%s CopyModel" % (existing, new))
+

--- a/pynest/pynestkernel.pxd
+++ b/pynest/pynestkernel.pxd
@@ -190,3 +190,7 @@ ctypedef fused numeric_buffer_t:
 
     buffer_float_1d_t
     buffer_double_1d_t
+
+# cdef inline Datum* python_object_to_datum(obj) except NULL
+# N.B. declaration here makes the function accessible to other cython modules; this does not affect from-Python importing
+

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -26,6 +26,7 @@ import cython
 
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
+from libc.stdint cimport uintptr_t
 
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -241,6 +242,12 @@ cdef class NESTEngine(object):
 
         return ret
 
+def _python_object_to_datum(obj):
+    """returns a Datum*"""
+    return __python_object_to_datum(obj)
+
+cdef inline uintptr_t __python_object_to_datum(obj) except 0:
+    return <uintptr_t>python_object_to_datum(obj)
 
 cdef inline Datum* python_object_to_datum(obj) except NULL:
 


### PR DESCRIPTION
Made `python_object_to_datum()` available to `hl_api_*.py` via Cython. The trick for the pointer is to typecast it to a `uintptr_t`, which is in the (Cython) stdlib.

The next step would be to make the functions in `nest.h` accessible to `hl_api_*.py` using Cython, starting with `copy_model()`.
