### PR TITLE
Arbor backend: check if enrolled

### DIFF
--- a/nestkernel/recording_backend_arbor.h
+++ b/nestkernel/recording_backend_arbor.h
@@ -63,6 +63,7 @@ public:
 private:
   void exchange_(std::vector<arb::shadow::spike>&);
 
+  bool enrolled_;
   bool prepared_;
 
   int steps_left_;


### PR DESCRIPTION
Backends must use their enrollment status to check whether they prepare, cleanup should be active