### PR TITLE
Fix compilation problems with gcc 5.4 regarding the Arbor rec. backend

### DIFF
--- a/nestkernel/mpiutil-impl.hpp
+++ b/nestkernel/mpiutil-impl.hpp
@@ -6,7 +6,8 @@
 #include <ostream>
 #include <type_traits>
 
-namespace arb::shadow {
+namespace arb {
+namespace shadow {
 
 struct cell_member_type {
     cell_gid_type gid;
@@ -98,7 +99,7 @@ struct comm_info {
 };
 
 comm_info get_comm_info(bool is_arbor, MPI_Comm comm) {
-    static_assert((sizeof(spike) % alignof(spike)) == 0);
+    static_assert((sizeof(spike) % alignof(spike)) == 0, "Alignment requirements of spike data type not met!");
     
     comm_info info;
     info.is_arbor = is_arbor;
@@ -140,4 +141,6 @@ comm_info get_comm_info(bool is_arbor, MPI_Comm comm) {
     return info;
 }
 
+
+} // namespace shadow
 } // namespace arb

--- a/nestkernel/mpiutil.hpp
+++ b/nestkernel/mpiutil.hpp
@@ -5,7 +5,8 @@
 #include <vector>
 #include <mpi.h>
 
-namespace arb::shadow {
+namespace arb {
+namespace shadow {
 
 using cell_gid_type = std::uint32_t;
 using cell_lid_type = std::uint32_t;
@@ -28,4 +29,6 @@ float broadcast(float local, MPI_Comm comm, int root);
 struct comm_info;
 comm_info get_comm_info(bool is_arbor, MPI_Comm comm);
 
+
+} // namespace shadow
 } // namespace arb


### PR DESCRIPTION
Some small code changes to get the code compiled with gcc 5.4 according to C++ 11 standard.