### PR TITLE
Write spike events in SpikeDetector::handle, not in update

### DIFF
--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -74,20 +74,6 @@ nest::spike_detector::calibrate()
 void
 nest::spike_detector::update( Time const&, const long, const long )
 {
-  for ( std::vector< Event* >::iterator e =
-          B_.spikes_[ kernel().event_delivery_manager.read_toggle() ].begin();
-        e != B_.spikes_[ kernel().event_delivery_manager.read_toggle() ].end();
-        ++e )
-  {
-    assert( *e != 0 );
-
-    RecordingDevice::write( **e );
-    delete *e;
-  }
-
-  // do not use swap here to clear, since we want to keep the reserved()
-  // memory for the next round
-  B_.spikes_[ kernel().event_delivery_manager.read_toggle() ].clear();
 }
 
 nest::RecordingDevice::Type
@@ -132,41 +118,12 @@ nest::spike_detector::handle( SpikeEvent& e )
   {
     assert( e.get_multiplicity() > 0 );
 
-    long dest_buffer;
-    if ( kernel()
-           .modelrange_manager.get_model_of_gid( e.get_sender_gid() )
-           ->has_proxies() )
-    {
-      // events from central queue
-      dest_buffer = kernel().event_delivery_manager.read_toggle();
-    }
-    else
-    {
-      // locally delivered events
-      dest_buffer = kernel().event_delivery_manager.write_toggle();
-    }
-
     for ( int i = 0; i < e.get_multiplicity(); ++i )
     {
+      RecordingDevice::write( e );
       // We store the complete events
-      Event* event = e.clone();
-      B_.spikes_[ dest_buffer ].push_back( event );
+      //Event* event = e.clone();
+      //B_.spikes_[ dest_buffer ].push_back( event );
     }
   }
 }
-
-
-//JME: Find out if the problem described in 1f3ce613a80 still exist with nestio
-//void
-//nest::spike_detector::finalize()
-//{
-//  // The order of the major simulation steps is:
-//  // update nodes -- gather spikes -- deliver spikes
-//  // Therefore, spikes from the last deliver might still reside in the
-//  // B_.spikes_ buffer and need to be recorded.
-//  // --> final call to update()
-//  const Time time;
-//  update( time, -1, -1 );
-//  device_.finalize();
-//}
-//


### PR DESCRIPTION
This enables us to record the last spike, and removes a lot of code!