### PR TITLE
fix missing ResetKernel in test_facetshw_stdp

### DIFF
--- a/pynest/nest/tests/test_facetshw_stdp.py
+++ b/pynest/nest/tests/test_facetshw_stdp.py
@@ -35,6 +35,8 @@ class FacetsTestCase(unittest.TestCase):
 
     def test_facetshw_stdp(self):
 
+        nest.ResetKernel()
+
         modelName = 'stdp_facetshw_synapse_hom'
 
         # homogeneous parameters for all synapses


### PR DESCRIPTION
The `test_facetshw_stdp` was missing a `nest.ResetKernel()`, which seemingly never caused a problem in master, but caused tests to fail now. The call should be there anyway to make tests independent of test order.