### PR TITLE
Make set_communicator accessible from nest module

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -24,6 +24,7 @@ Initializer of PyNEST.
 """
 
 from . import ll_api                  # noqa
+from .ll_api import set_communicator  # noqa
 
 from . import pynestkernel as kernel  # noqa
 from .hl_api import *                 # noqa


### PR DESCRIPTION
`set_communicator` should be callable on `nest`.

This is the minimal change to make it happen -- otherwise, engine needs to be set, yadda, yadda, yadda.