### PR TITLE
WIP: Nest function mapping fixes 

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -289,13 +289,17 @@ def serialize(call, args, kwargs):
     if call.__name__.startswith('Set'):
         status = {}
         if call.__name__ == 'SetDefaults':
-            status = nest.GetDefaults(kwargs['model'])
-        elif call.__name__ == 'SetKernelStatus':
+#            status = nest.GetDefaults(kwargs['model'])
+            status = nest.GetDefaults()
+        elif call.__name__ == 'GetKernelStatus':
             status = nest.GetKernelStatus()
+        elif call.__name__ == 'SetKernelStatus':
+            status = nest.SetKernelStatus(kwargs['params'])
         elif call.__name__ == 'SetStructuralPlasticityStatus':
             status = nest.GetStructuralPlasticityStatus(kwargs['params'])
         elif call.__name__ == 'SetStatus':
-            status = nest.GetStatus(kwargs['nodes'])
+#            status = nest.GetStatus(kwargs['nodes'])
+            status = nest.SetStatus(kwargs['nodes'], kwargs['params'])
         for key, val in kwargs['params'].items():
             if key in status:
                 kwargs['params'][key] = type(status[key])(val)


### PR DESCRIPTION
@jougs I could be wrong but it seems to me that there is an issue with some function mappings, however they doesn't solve the issue I'm having in running 

./run_benchmarks.py clisrv -o results_clisrv.txt testcase_nrp.py

whose execution seems to stop during the call to 

engine.run('{%s} runprotected' % decode(cmd)) 

in nest/ll_api.py. The "Temporal resolution changed." log message is printed by the server but then nothing happens.  