### PR TITLE
Revised help info and prettified error message

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -19,20 +19,22 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-"""PyNEST - Python bindings for the NEST simulator
+"""PyNEST - Python interface for the NEST simulator
 
-Type ``nest.helpdesk()`` to access the online documentation.
-Type ``nest.help(object)`` to get help on a NEST object.
-Type ``nest.__version__`` to get the NEST version.
+* ``nest.helpdesk()`` opens the NEST documentation in your browser.
 
-* see documentation for neuron or synapse models by typing
-  ``nest.help('model_name')``
+* ``nest.__version__`` displays the NEST version.
 
-* see the documentation of a PyNEST API function, by typing
-  something like ``help(nest.Create)``
+* ``nest.Models()`` shows all available neuron, device and synapse models.
 
-* get a list of available models by typing ``nest.Models()``
+* ``nest.help('model_name') displays help for the given model, e.g., ``nest.help('iaf_psc_exp')``
 
+* To get help on functions in the ``nest`` package, use Python's ``help()`` function
+  or IPython's ``?`` to get help, e.g.
+
+     - ``help(nest.Create)``
+     - ``nest.Connect?``
+  
 For more information visit https://www.nest-simulator.org.
 
 """

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -30,7 +30,7 @@
 * ``nest.help('model_name') displays help for the given model, e.g., ``nest.help('iaf_psc_exp')``
 
 * To get help on functions in the ``nest`` package, use Python's ``help()`` function
-  or IPython's ``?`` to get help, e.g.
+  or IPython's ``?``, e.g.
 
      - ``help(nest.Create)``
      - ``nest.Connect?``

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -25,6 +25,7 @@ Functions to get information on NEST.
 
 import sys
 import os
+import textwrap
 import webbrowser
 
 from ..ll_api import *
@@ -114,10 +115,17 @@ def help(obj=None, return_text=False):
     """
 
     if obj is not None:
-        if return_text:
-            return load_help(obj)
-        else:
-            show_help_with_pager(obj)
+        try:
+            if return_text:
+                return load_help(obj)
+            else:
+                show_help_with_pager(obj)
+        except FileNotFoundError:
+            print(textwrap.dedent(
+                  f"""
+                   Sorry, there is no help for model '{obj}'.
+                   Use the Python help() function to obtain help on PyNEST functions.""")
+                 )
     else:
         print(nest.__doc__)
 


### PR DESCRIPTION
@jougs I wrapped a try-except around `help()` so the user isn't faced with a stack trace when asking for help on something that no help is available for. I also rewrote the `nest.__doc__` to avoid some duplication and make even clearer the difference between `nest.help()` and Python `help()`.