### PR TITLE
Dynamic generation of the nest module and the kernel attributes.

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -93,9 +93,9 @@ def rel_import_star(module_name):
     module_dict = vars(module).items()
     if hasattr(module, "__all__"):
         all = module.__all__
-        _module_dict.update(kv for kv in module_dict if kv[0] in all)
+        _module_dict.update(p for p in module_dict if p[0] in all)
     else:
-        _module_dict.update(kv for kv in module_dict if not kv[0].startswith("_"))
+        _module_dict.update(p for p in module_dict if not p[0].startswith("_"))
 
 # Import public API of `.hl_api` into the module instance
 rel_import_star(".hl_api")

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -129,7 +129,7 @@ class KernelAttribute:
         self._readonly = readonly
 
     def __get__(self, instance, cls=None):
-        if cls is not None:
+        if instance is None:
             return self
         return instance.GetKernelStatus(self._name)
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -37,6 +37,175 @@
 
 For more information visit https://www.nest-simulator.org.
 
+Kernel attributes
+=================
+
+**Note**
+
+All NEST kernel attributes are described below, grouped by topic.
+Some of them only provide information about the kernel status and
+cannot be set by the user, these are marked as *read only*.
+
+
+Time and resolution
+-------------------
+
+resolution : float, default: 0.1
+    The resolution of the simulation (in ms)
+time : float
+    The current simulation time (in ms)
+to_do : int, read only
+    The number of steps yet to be simulated
+max_delay : float, default: 0.1
+    The maximum delay in the network
+min_delay : float, default: 0.1
+    The minimum delay in the network
+ms_per_tic : float, default: 0.001
+    The number of milliseconds per tic
+tics_per_ms : float, default: 1000.0
+    The number of tics per millisecond
+tics_per_step : int, default: 100
+    The number of tics per simulation time step
+T_max : float, read only
+    The largest representable time value
+T_min : float, read only
+    The smallest representable time value
+
+
+Random number generators
+------------------------
+
+rng_types : list, read only
+    Names of random number generator types available.
+    Types: "Philox_32", "Philox_64", "Threefry_32", "Threefry_64", "mt19937", "mt19937_64"
+rng_type : str, default: mt19937_64
+    Name of random number generator type used by NEST.
+rng_seed : int, default: 143202461
+    Seed value used as base for seeding NEST random number generators
+    (:math:`1 \leq s \leq 2^{32}-1`).
+
+
+Parallel processing
+-------------------
+
+total_num_virtual_procs : int, default: 1
+    The total number of virtual processes
+local_num_threads : int, default: 1
+    The local number of threads
+num_processes : int, read only
+    The number of MPI processes
+off_grid_spiking : bool, read only
+    Whether to transmit precise spike times in MPI communication
+
+
+MPI buffers
+-----------
+
+adaptive_spike_buffers  : bool, default: True
+    Whether MPI buffers for communication of spikes resize on the fly
+adaptive_target_buffers : bool, default: True
+    Whether MPI buffers for communication of connections resize on the fly
+buffer_size_secondary_events : int, read only
+    Size of MPI buffers for communicating secondary events (in bytes, per
+    MPI rank, for developers)
+buffer_size_spike_data : int, default: 2
+    Total size of MPI buffer for communication of spikes
+buffer_size_target_data : int, default: 2
+    Total size of MPI buffer for communication of connections
+growth_factor_buffer_spike_data : float, default: 1.5
+    If MPI buffers for communication of spikes resize on the fly, grow
+    them by this factor each round
+growth_factor_buffer_target_data : float, default: 1.5
+    If MPI buffers for communication of connections resize on the fly, grow
+    them by this factor each round
+max_buffer_size_spike_data : int, default: 8388608
+    Maximal size of MPI buffers for communication of spikes.
+max_buffer_size_target_data : int, default: 16777216
+    Maximal size of MPI buffers for communication of connections
+
+
+Gap junctions and rate models (waveform relaxation method)
+----------------------------------------------------------
+
+use_wfr : bool, default: True
+    Whether to use waveform relaxation method
+wfr_comm_interval : float, default: 1.0
+    Desired waveform relaxation communication interval
+wfr_tol : float, default: 0.0001
+    Convergence tolerance of waveform relaxation method
+wfr_max_iterations : int, default: 15
+    Maximal number of iterations used for waveform relaxation
+wfr_interpolation_order : int, default: 3
+    Interpolation order of polynomial used in wfr iterations
+
+
+Synapses
+--------
+
+max_num_syn_models : int, read only
+    Maximal number of synapse models supported
+sort_connections_by_source : bool, default: True
+    Whether to sort connections by their source; increases construction
+    time of presynaptic data structures, decreases simulation time if the
+    average number of outgoing connections per neuron is smaller than the
+    total number of threads
+structural_plasticity_synapses : dict
+    Defines all synapses which are plastic for the structural plasticity
+    algorithm. Each entry in the dictionary is composed of a synapse model,
+    the pre synaptic element and the postsynaptic element
+structural_plasticity_update_interval : int, default: 10000.0
+    Defines the time interval in ms at which the structural plasticity
+    manager will make changes in the structure of the network (creation
+    and deletion of plastic synapses)
+use_compressed_spikes : bool, default: True
+    Whether to use spike compression; if a neuron has targets on
+    multiple threads of a process, this switch makes sure that only
+    a single packet is sent to the process instead of one packet per
+    target thread; requires sort_connections_by_source = true
+
+
+Output
+------
+
+data_path : str
+    A path, where all data is written to (default is the current
+    directory)
+data_prefix : str
+    A common prefix for all data files
+overwrite_files : bool, default: False
+    Whether to overwrite existing data files
+print_time : bool, default: False
+    Whether to print progress information during the simulation
+network_size : int, read only
+    The number of nodes in the network
+num_connections : int, read only, local only
+    The number of connections in the network
+local_spike_counter : int, read only
+    Number of spikes fired by neurons on a given MPI rank during the most
+    recent call to :py:func:`.Simulate`. Only spikes from "normal" neurons
+    are counted, not spikes generated by devices such as ``poisson_generator``.
+recording_backends : list of str
+    List of available backends for recording devices:
+    "memory", "ascii", "screen"
+
+
+Miscellaneous
+-------------
+
+dict_miss_is_error : bool, default: True
+    Whether missed dictionary entries are treated as errors
+keep_source_table : bool, default: True
+    Whether to keep source table after connection setup is complete
+min_update_time: double, read only
+    Shortest wall-clock time measured so far for a full update step [seconds].
+max_update_time: double, read only
+    Longest wall-clock time measured so far for a full update step [seconds].
+update_time_limit: double
+    Maximum wall-clock time for one full update step in seconds, default +inf.
+    This can be used to terminate simulations that slow down significantly.
+    Simulations may still get stuck if the slowdown occurs within a single update
+    step.
+
 """
 
 
@@ -44,6 +213,7 @@ For more information visit https://www.nest-simulator.org.
 # instance later on. Use `.copy()` to prevent pollution with other variables
 _original_module_attrs = globals().copy()
 
+from .ll_api import KernelAttribute
 import sys, types, importlib
 if sys.version_info[0] == 2:
     msg = "Python 2 is no longer supported. Please use Python >= 3.6."
@@ -104,11 +274,14 @@ class NestModule(types.ModuleType):
 
     # Lazy load the `spatial` module to avoid circular imports.
     spatial = _lazy_module_property("spatial")
+    # Property for the full SLI `GetKernelStatus` dictionary
+    kernel_status = KernelAttribute(None, "Get kernel status.", readonly=True)
 
     __version__ = ll_api.sli_func("statusdict /version get")
 
     def __dir__(self):
         return list(set(vars(self).keys()) | set(self.__all__))
+
 
 # Instantiate a NestModule
 _module = NestModule(__name__)
@@ -121,40 +294,19 @@ _module_dict.update(_original_module_attrs)
 # Import public API of `.hl_api` into the nest module instance
 _rel_import_star(_module_dict, ".hl_api")
 
-class KernelAttribute:
-    """
-    A `KernelAttribute` dispatches attribute access of a `nest` attribute to the
-    nest kernel by deferring to `nestGetKernelStatus` or `nest.SetKernelStatus`.
-    """
-    def __init__(self, name, doc, readonly=False):
-        self._name = name
-        self.__doc__ = doc
-        self._readonly = readonly
-
-    def __get__(self, instance, cls=None):
-        if instance is None:
-            return self
-        return instance.GetKernelStatus(self._name)
-
-    def __set__(self, instance, value):
-        if self._readonly:
-            msg = f"`{self._name}` is a read only kernel attribute."
-            raise AttributeError(msg)
-        return instance.SetKernelStatus({self._name: value})
-
-# Parse the `SetKernelStatus` docstring to obtain the kernel attributes.
-_doc_lines = _module.SetKernelStatus.__doc__.split('\n')
-# Get the lines describing parameters
-_param_lines = (line for line in _doc_lines if ' : ' in line)
-# Exclude the first parameter `params`.
-next(_param_lines)
-# Process each parameter line into a KernelAttribute and add it to the nest
-# module instance.
-for ln in _param_lines:
-    _param = ln.split(":")[0].strip()
-    _readonly = "read only" in ln
+_kernel_attr_names = set()
+# Parse this module's docstring to obtain the kernel attributes.
+for _line in __doc__.split('\n'):
+    # Parse the `parameter : description. read only` lines
+    if not ' : ' in _line:
+        continue
+    _param = _line.split(":")[0].strip()
+    _readonly = "read only" in _line
+    _kernel_attr_names.add(_param)
+    # Create a kernel attribute descriptor and add it to the nest module
     _kernel_attr = KernelAttribute(_param, None, _readonly)
     setattr(NestModule, _param, _kernel_attr)
+_module._kernel_attr_names = _kernel_attr_names
 
 # Finalize the nest module instance by generating its public API.
 _api = list(k for k in _module_dict if not k.startswith("_"))
@@ -171,5 +323,5 @@ sys.modules[__name__] = _module
 globals().update(_module_dict)
 
 # Clean up obsolete references
-del _param_lines, _doc_lines, _rel_import_star, _lazy_module_property, \
-    _param, _readonly, _kernel_attr, _module_dict, _original_module_attrs
+del _kernel_attr_names, _rel_import_star, _lazy_module_property, _readonly, \
+    _kernel_attr, _module, _module_dict, _original_module_attrs, _line, _param

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -138,7 +138,8 @@ class KernelAttribute:
 
     def __set__(self, instance, value):
         if self._readonly:
-            raise ValueError(f"`{self._name}` is a read only kernel attribute.")
+            msg = f"`{self._name}` is a read only kernel attribute."
+            raise AttributeError(msg)
         return instance.SetKernelStatus({self._name: value})
 
 # Parse the `SetKernelStatus` docstring to obtain the kernel attributes.

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -153,7 +153,9 @@ for ln in _param_lines:
     setattr(NestModule, _param, _kernel_attr)
 
 # Finalize the nest module instance by generating its public API.
-_module.__all__ = list(k for k in _module_dict if not k.startswith("_"))
+_api = list(k for k in _module_dict if not k.startswith("_"))
+_api.extend(k for k in dir(NestModule) if not k.startswith("_"))
+_module.__all__ = list(set(_api))
 
 # Set the nest module object as the return value of `import nest` using sys
 sys.modules[__name__] = _module

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -107,6 +107,9 @@ class NestModule(types.ModuleType):
 
     __version__ = ll_api.sli_func("statusdict /version get")
 
+    def __dir__(self):
+        return list(set(vars(self).keys()) | set(self.__all__))
+
 # Instantiate a NestModule
 _module = NestModule(__name__)
 # We manipulate the nest module instance through its `__dict__` (= vars())

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -90,12 +90,11 @@ def rel_import_star(module_name):
     # Emulate a bit of import machinery to replace module level
     # `from .X import *` statements.
     module = importlib.import_module(module_name, __name__)
-    module_dict = vars(module).items()
+    mod_iter = vars(module).items()
     if hasattr(module, "__all__"):
-        all = module.__all__
-        _module_dict.update(p for p in module_dict if p[0] in all)
+        _module_dict.update(kv for kv in mod_iter if kv[0] in module.__all__)
     else:
-        _module_dict.update(p for p in module_dict if not p[0].startswith("_"))
+        _module_dict.update(kv for kv in mod_iter if not kv[0].startswith("_"))
 
 # Import public API of `.hl_api` into the module instance
 rel_import_star(".hl_api")

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -427,16 +427,6 @@ def SetKernelStatus(params):
     sr('SetKernelStatus')
 
 
-# Parse the `SetKernelStatus` docstring to obtain all valid and readonly params
-doc_lines = SetKernelStatus.__doc__.split('\n')
-# Get the lines describing parameters
-param_lines = (line.strip() for line in doc_lines if ' : ' in line)
-# Exclude the first parameter `params`.
-next(param_lines)
-_sks_params = {ln.split(" :")[0]: "read only" in ln for ln in param_lines}
-del doc_lines, param_lines
-
-
 @check_stack
 def GetKernelStatus(keys=None):
     """Obtain parameters of the simulation kernel.

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -196,9 +196,9 @@ def ResetKernel():
     sr('ResetKernel')
 
 
-@check_stack
 def SetKernelStatus(params):
-    r"""Set parameters for the simulation kernel.
+    """Set parameters for the simulation kernel. See the nest module attribute
+    documentation for a valid list of params.
 
     Parameters
     ----------
@@ -206,216 +206,25 @@ def SetKernelStatus(params):
     params : dict
         Dictionary of parameters to set.
 
-
-    **Note**
-
-    All NEST kernel parameters are described below, grouped by topic.
-    Some of them only provide information about the kernel status and
-    cannot be set by the user. These are marked as *read only* and can
-    be accessed using ``GetKernelStatus``.
-
-
-    **Time and resolution**
-
-    Parameters
-    ----------
-
-    resolution : float, default: 0.1
-        The resolution of the simulation (in ms)
-    time : float
-        The current simulation time (in ms)
-    to_do : int, read only
-        The number of steps yet to be simulated
-    max_delay : float, default: 0.1
-        The maximum delay in the network
-    min_delay : float, default: 0.1
-        The minimum delay in the network
-    ms_per_tic : float, default: 0.001
-        The number of milliseconds per tic
-    tics_per_ms : float, default: 1000.0
-        The number of tics per millisecond
-    tics_per_step : int, default: 100
-        The number of tics per simulation time step
-    T_max : float, read only
-        The largest representable time value
-    T_min : float, read only
-        The smallest representable time value
-
-
-    **Random number generators**
-
-    Parameters
-    ----------
-
-    rng_types : list, read only
-        Names of random number generator types available.
-        Types: "Philox_32", "Philox_64", "Threefry_32", "Threefry_64", "mt19937", "mt19937_64"
-    rng_type : str, default: mt19937_64
-        Name of random number generator type used by NEST.
-    rng_seed : int, default: 143202461
-        Seed value used as base for seeding NEST random number generators
-        (:math:`1 \leq s \leq 2^{32}-1`).
-
-
-    **Parallel processing**
-
-    Parameters
-    ----------
-
-    total_num_virtual_procs : int, default: 1
-        The total number of virtual processes
-    local_num_threads : int, default: 1
-        The local number of threads
-    num_processes : int, read only
-        The number of MPI processes
-    off_grid_spiking : bool, read only
-        Whether to transmit precise spike times in MPI communication
-
-
-    **MPI buffers**
-
-    Parameters
-    ----------
-
-    adaptive_spike_buffers  : bool, default: True
-        Whether MPI buffers for communication of spikes resize on the fly
-    adaptive_target_buffers : bool, default: True
-        Whether MPI buffers for communication of connections resize on the fly
-    buffer_size_secondary_events : int, read only
-        Size of MPI buffers for communicating secondary events (in bytes, per
-        MPI rank, for developers)
-    buffer_size_spike_data : int, default: 2
-        Total size of MPI buffer for communication of spikes
-    buffer_size_target_data : int, default: 2
-        Total size of MPI buffer for communication of connections
-    growth_factor_buffer_spike_data : float, default: 1.5
-        If MPI buffers for communication of spikes resize on the fly, grow
-        them by this factor each round
-    growth_factor_buffer_target_data : float, default: 1.5
-        If MPI buffers for communication of connections resize on the fly, grow
-        them by this factor each round
-    max_buffer_size_spike_data : int, default: 8388608
-        Maximal size of MPI buffers for communication of spikes.
-    max_buffer_size_target_data : int, default: 16777216
-        Maximal size of MPI buffers for communication of connections
-
-
-    **Gap junctions and rate models (waveform relaxation method)**
-
-    Parameters
-    ----------
-
-    use_wfr : bool, default: True
-        Whether to use waveform relaxation method
-    wfr_comm_interval : float, default: 1.0
-        Desired waveform relaxation communication interval
-    wfr_tol : float, default: 0.0001
-        Convergence tolerance of waveform relaxation method
-    wfr_max_iterations : int, default: 15
-        Maximal number of iterations used for waveform relaxation
-    wfr_interpolation_order : int, default: 3
-        Interpolation order of polynomial used in wfr iterations
-
-
-    **Synapses**
-
-    Parameters
-    ----------
-
-    max_num_syn_models : int, read only
-        Maximal number of synapse models supported
-    sort_connections_by_source : bool, default: True
-        Whether to sort connections by their source; increases construction
-        time of presynaptic data structures, decreases simulation time if the
-        average number of outgoing connections per neuron is smaller than the
-        total number of threads
-    structural_plasticity_synapses : dict
-        Defines all synapses which are plastic for the structural plasticity
-        algorithm. Each entry in the dictionary is composed of a synapse model,
-        the pre synaptic element and the postsynaptic element
-    structural_plasticity_update_interval : int, default: 10000.0
-        Defines the time interval in ms at which the structural plasticity
-        manager will make changes in the structure of the network (creation
-        and deletion of plastic synapses)
-    use_compressed_spikes : bool, default: True
-        Whether to use spike compression; if a neuron has targets on
-        multiple threads of a process, this switch makes sure that only
-        a single packet is sent to the process instead of one packet per
-        target thread; requires sort_connections_by_source = true
-
-
-    **Output**
-
-    Parameters
-    -------
-
-    data_path : str
-        A path, where all data is written to (default is the current
-        directory)
-    data_prefix : str
-        A common prefix for all data files
-    overwrite_files : bool, default: False
-        Whether to overwrite existing data files
-    print_time : bool, default: False
-        Whether to print progress information during the simulation
-    network_size : int, read only
-        The number of nodes in the network
-    num_connections : int, read only, local only
-        The number of connections in the network
-    local_spike_counter : int, read only
-        Number of spikes fired by neurons on a given MPI rank during the most
-        recent call to :py:func:`.Simulate`. Only spikes from "normal" neurons
-        are counted, not spikes generated by devices such as ``poisson_generator``.
-    recording_backends : list of str
-        List of available backends for recording devices:
-        "memory", "ascii", "screen"
-
-
-    **Miscellaneous**
-
-    Parameters
-    ----------
-
-    dict_miss_is_error : bool, default: True
-        Whether missed dictionary entries are treated as errors
-    keep_source_table : bool, default: True
-        Whether to keep source table after connection setup is complete
-    min_update_time: double, read only
-        Shortest wall-clock time measured so far for a full update step [seconds].
-    max_update_time: double, read only
-        Longest wall-clock time measured so far for a full update step [seconds].
-    update_time_limit: double
-        Maximum wall-clock time for one full update step in seconds, default +inf.
-        This can be used to terminate simulations that slow down significantly.
-        Simulations may still get stuck if the slowdown occurs within a single update
-        step.
-
     See Also
     --------
 
     get, GetKernelStatus
 
     """
-    # Resolve if missing entries should raise errors
-    raise_errors = params.get('dict_miss_is_error')
-    if raise_errors is None:
-        raise_errors = GetKernelStatus('dict_miss_is_error')
-
-    # Check validity of passed parameters
+    import nest
+    raise_errors = params.get('dict_miss_is_error', nest.dict_miss_is_error)
+    # Double-check validity of the given params here to prevent accidental
+    # mutation of the nest module by the `setattr` statement at the end of the
+    # function.
+    valids = nest._kernel_attr_names
     keys = list(params.keys())
     for key in keys:
-        readonly = _sks_params.get(key)
         msg = None
-        if readonly is None:
-            # If the parameter is not in the docstring
+        if key not in valids:
             msg = f'`{key}` is not a valid kernel parameter, ' + \
                   'valid parameters are: ' + \
-                  ', '.join(f"'{p}'" for p in _sks_params.keys())
-        elif readonly:
-            # If the parameter is tagged as read only
-            msg = f'`{key}` is a read only parameter and cannot ' + \
-                  'be defined using SetKernelStatus'
-        # Raise error or warn the user
+                  ', '.join(f"'{p}'" for p in sorted(valids))
         if msg is not None:
             if raise_errors:
                 raise ValueError(msg)
@@ -423,20 +232,10 @@ def SetKernelStatus(params):
                 warnings.warn(msg + f' \n`{key}` has been ignored')
                 del params[key]
 
-    sps(params)
-    sr('SetKernelStatus')
+    for k, v in params.items():
+        setattr(nest, k, v)
 
 
-# Parse the `SetKernelStatus` docstring to obtain all valid and readonly params
-doc_lines = SetKernelStatus.__doc__.split('\n')
-# Get the lines describing parameters
-param_lines = (line for line in doc_lines if ' : ' in line)
-# Exclude the first parameter `params`.
-next(param_lines)
-_sks_params = {ln.split(":")[0].strip(): "read only" in ln for ln in param_lines}
-del doc_lines, param_lines
-
-@check_stack
 def GetKernelStatus(keys=None):
     """Obtain parameters of the simulation kernel.
 
@@ -472,8 +271,8 @@ def GetKernelStatus(keys=None):
 
     """
 
-    sr('GetKernelStatus')
-    status_root = spp()
+    import nest
+    status_root = nest.kernel_status
 
     if keys is None:
         return status_root

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -197,8 +197,9 @@ def ResetKernel():
 
 
 def SetKernelStatus(params):
-    """Set parameters for the simulation kernel. See the nest module attribute
-    documentation for a valid list of params.
+    """Set parameters for the simulation kernel.
+    
+    See the nest module attribute documentation for a valid list of params.
 
     Parameters
     ----------

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -220,12 +220,10 @@ def SetKernelStatus(params):
     valids = nest._kernel_attr_names
     keys = list(params.keys())
     for key in keys:
-        msg = None
         if key not in valids:
             msg = f'`{key}` is not a valid kernel parameter, ' + \
                   'valid parameters are: ' + \
                   ', '.join(f"'{p}'" for p in sorted(valids))
-        if msg is not None:
             if raise_errors:
                 raise ValueError(msg)
             else:

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -427,6 +427,15 @@ def SetKernelStatus(params):
     sr('SetKernelStatus')
 
 
+# Parse the `SetKernelStatus` docstring to obtain all valid and readonly params
+doc_lines = SetKernelStatus.__doc__.split('\n')
+# Get the lines describing parameters
+param_lines = (line for line in doc_lines if ' : ' in line)
+# Exclude the first parameter `params`.
+next(param_lines)
+_sks_params = {ln.split(":")[0].strip(): "read only" in ln for ln in param_lines}
+del doc_lines, param_lines
+
 @check_stack
 def GetKernelStatus(keys=None):
     """Obtain parameters of the simulation kernel.

--- a/pynest/nest/ll_api.py
+++ b/pynest/nest/ll_api.py
@@ -273,6 +273,37 @@ def check_stack(thing):
         raise ValueError("unable to decorate {0}".format(thing))
 
 
+class KernelAttribute:
+    """
+    Descriptor that dispatches attribute access to the nest kernel.
+    """
+    def __init__(self, name, doc, readonly=False):
+        self._name = name
+        self.__doc__ = doc
+        self._readonly = readonly
+
+    @stack_checker
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+
+        sr('GetKernelStatus')
+        status_root = spp()
+
+        if self._name is None:
+            return status_root
+        else:
+            return status_root[self._name]
+
+    @stack_checker
+    def __set__(self, instance, value):
+        if self._readonly:
+            msg = f"`{self._name}` is a read only kernel attribute."
+            raise AttributeError(msg)
+        sps({self._name: value})
+        sr('SetKernelStatus')
+
+
 initialized = False
 
 


### PR DESCRIPTION
A few notes on what I don't like about it currently:

* There's a lot of logic in `SetKernelStatus` and `GetKernelStatus` that could actually be skipped when using the attributes
* There's code duplication of the parsing of the docstring of `SetKernelStatus`, I don't think this can be prevented unless we either do it once in a new module that both modules import it from, or make this dictionary part of a public API of either module and import it in the other. I don't like either, you can choose :D

Then a nitpicky note going over the code, there are too many `from X import *` statements which are less clear than listing exactly what is imported from where and make it hard to determine when an import is still required in a file or not, it's also harder to track down which module references in a file came from. To keep in mind as a little to-do together with how the imports are rigged after any major changes when phasing out SLI from the Python interface happens.