### PR TITLE
Add more casts to Cython conversion table

### DIFF
--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -45,6 +45,7 @@ import numpy
 
 
 from libc.stdlib cimport malloc, free
+from libc.stdint cimport uint64_t, int64_t
 
 
 def init(args):
@@ -133,6 +134,10 @@ cdef object any_to_pyobj(any operand):
         return any_cast[long](operand)
     if is_type[size_t](operand):
         return any_cast[size_t](operand)
+    if is_type[uint64_t](operand):
+        return any_cast[uint64_t](operand)
+    if is_type[int64_t](operand):
+        return any_cast[int64_t](operand)
     if is_type[double](operand):
         return any_cast[double](operand)
     if is_type[cbool](operand):


### PR DESCRIPTION
Currently, `nest.set(**params)` and `nest.SetKernelStatus(**params)` fails with the following traceback:

```
Traceback (most recent call last):
  File "/Users/nicolai/github/nest_dev/nest/build/../nest-simulator/pynest/examples/dev_set_kernel_status.py", line 26, in <module>
    nest.set(total_num_virtual_procs=n_vps, print_time=True)
  File "/Users/nicolai/github/nest_dev/nest/build/install/lib/python3.9/site-packages/nest/__init__.py", line 114, in set
    return self.SetKernelStatus(kwargs)
  File "/Users/nicolai/github/nest_dev/nest/build/install/lib/python3.9/site-packages/nest/lib/hl_api_simulation.py", line 216, in SetKernelStatus
    raise_errors = params.get('dict_miss_is_error', nest.dict_miss_is_error)
  File "/Users/nicolai/github/nest_dev/nest/build/install/lib/python3.9/site-packages/nest/ll_api.py", line 113, in __get__
    status_root = nestkernel.llapi_get_kernel_status()
  File "nestkernel_api.pyx", line 289, in nestkernel_api.catch_cpp_error.wrapper_catch_cpp_error
nest.lib.hl_api_exceptions.NESTErrors.NESTError: in llapi_get_kernel_status: Could not convert: max_num_syn_models of type unsigned long long
```

The error is due to `max_num_syn_models` being set by `MAX_SYN_ID`, which is of type `uint64_t` (see `nest_types.h`). There are no casts for `uint64_t` or `int64_t` in the Cython conversion table.

This PR adds these missing conversions. I am not sure if we should include more casts, but at least `nest.set` and `nest.SetKernelStatus` works now. 