### PR TITLE
Add missing overrides

### DIFF
--- a/nestkernel/conn_parameter.h
+++ b/nestkernel/conn_parameter.h
@@ -231,7 +231,6 @@ private:
  * - All parameters are  doubles, thus calling the function value_int()
  *   throws an error.
  */
-
 class ArrayDoubleParameter : public ConnParameter
 {
 public:
@@ -274,7 +273,7 @@ public:
   }
 
   long
-  value_int( thread, RngPtr, index, Node* ) const
+  value_int( thread, RngPtr, index, Node* ) const override
   {
     throw KernelException( "ConnParameter calls value function with false return type." );
   }
@@ -313,7 +312,6 @@ private:
  * - All parameters are integer, thus calling the function value_double()
  *   throws an error.
  */
-
 class ArrayLongParameter : public ConnParameter
 {
 public:

--- a/nestkernel/growth_curve.h
+++ b/nestkernel/growth_curve.h
@@ -128,7 +128,8 @@ public:
   void get( dictionary& d ) const override;
   void set( const dictionary& d ) override;
 
-  double update( double t, double t_minus, double Ca_minus, double z, double tau_Ca, double growth_rate ) const;
+  double
+  update( double t, double t_minus, double Ca_minus, double z, double tau_Ca, double growth_rate ) const override;
 
 private:
   double eps_;
@@ -213,10 +214,11 @@ class GrowthCurveGaussian : public GrowthCurve
 {
 public:
   GrowthCurveGaussian();
-  void get( dictionary& d ) const;
-  void set( const dictionary& d );
+  void get( dictionary& d ) const override;
+  void set( const dictionary& d ) override;
 
-  double update( double t, double t_minus, double Ca_minus, double z, double tau_Ca, double growth_rate ) const;
+  double
+  update( double t, double t_minus, double Ca_minus, double z, double tau_Ca, double growth_rate ) const override;
 
 private:
   double eta_;

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -90,7 +90,7 @@ public:
   void sends_secondary_event( DelayedRateConnectionEvent& ) override;
 
   void
-  handle( SpikeEvent& )
+  handle( SpikeEvent& ) override
   {
   }
 


### PR DESCRIPTION
Some derived classes were missing overrides for virtual functions, which generated a lot of warnings during compilation. This PR adds those overrides. There are still some compiler warnings left, but these are isolated to `exceptions.cpp`. I will try to address the `exceptions.cpp` warnings in a separate PR. 